### PR TITLE
backend 2 - persistance

### DIFF
--- a/apps/backend/.gitignore
+++ b/apps/backend/.gitignore
@@ -33,3 +33,6 @@ lerna-debug.log*
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+# Prisma
+prisma/dev.db

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -44,6 +44,7 @@
     "eslint-plugin-prettier": "^5.0.0",
     "jest": "^29.5.0",
     "prettier": "^3.0.0",
+    "prisma": "^5.7.1",
     "source-map-support": "^0.5.21",
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.0",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -23,6 +23,7 @@
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
+    "@prisma/client": "^5.7.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "reflect-metadata": "^0.1.13",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -17,7 +17,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+	"postinstall": "yarn prisma generate"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -1,0 +1,11 @@
+// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -9,3 +9,25 @@ datasource db {
   provider = "sqlite"
   url      = env("DATABASE_URL")
 }
+
+model Payable {
+	id String @id @default(uuid())
+
+	value Float
+	emissionDate DateTime
+
+	assignor Assignor?
+}
+
+model Assignor {
+	id String @id @default(uuid())
+
+	document String
+	email String
+	phone String
+	name String
+
+	payable_id String @unique
+
+	payable Payable @relation(fields: [payable_id], references: [id], onDelete: Cascade)
+}

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -16,7 +16,9 @@ model Payable {
 	value Float
 	emissionDate DateTime
 
-	assignor Assignor?
+	assignor_id String @unique
+
+	assignor Assignor @relation(fields: [assignor_id], references: [id], onDelete: Cascade)
 }
 
 model Assignor {
@@ -27,7 +29,5 @@ model Assignor {
 	phone String
 	name String
 
-	payable_id String @unique
-
-	payable Payable @relation(fields: [payable_id], references: [id], onDelete: Cascade)
+	payable Payable[]
 }

--- a/apps/backend/src/domains/app.module.ts
+++ b/apps/backend/src/domains/app.module.ts
@@ -6,11 +6,12 @@ import { AppService } from './app/app.service';
 import { AppController } from './app/app.controller';
 
 // Domains
+import { AuthModule } from './auth/auth.module';
 import { PayableModule } from './payable/payable.module';
 import { AssignorModule } from './assignor/assignor.module';
 
 @Module({
-  imports: [PayableModule, AssignorModule],
+  imports: [PayableModule, AssignorModule, AuthModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/apps/backend/src/domains/app.module.ts
+++ b/apps/backend/src/domains/app.module.ts
@@ -7,9 +7,10 @@ import { AppController } from './app/app.controller';
 
 // Domains
 import { PayableModule } from './payable/payable.module';
+import { AssignorModule } from './assignor/assignor.module';
 
 @Module({
-  imports: [PayableModule],
+  imports: [PayableModule, AssignorModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/apps/backend/src/domains/assignor/assignor.controller.ts
+++ b/apps/backend/src/domains/assignor/assignor.controller.ts
@@ -1,0 +1,81 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  Res,
+  UsePipes,
+} from '@nestjs/common';
+import { AssignorService } from './assignor.service';
+import { ZodValidationPipe } from 'src/pipes/zod.validation.pipe';
+import { Response } from 'express';
+import {
+  PaginationSchema,
+  paginationSchema,
+} from 'src/schemas/pagination.schema';
+import {
+  CreateAssignorSchema,
+  createAssignorSchema,
+} from 'src/schemas/assignor.schema';
+
+@Controller('integrations/assignor')
+export class AssignorController {
+  constructor(private readonly service: AssignorService) {}
+
+  @Get()
+  @UsePipes(new ZodValidationPipe(paginationSchema))
+  async index(@Query() query: PaginationSchema) {
+    const [data, metadata] = await this.service.index(query);
+
+    return {
+      data,
+      ...metadata,
+    };
+  }
+
+  @Post()
+  async store(
+    @Body(new ZodValidationPipe(createAssignorSchema))
+    payload: CreateAssignorSchema,
+  ) {
+    const data = await this.service.store(payload);
+
+    return { data };
+  }
+
+  @Get(':id')
+  async show(@Param() params: { id: string }, @Res() res: Response) {
+    const data = await this.service.show(params.id);
+
+    if (!data) return res.status(404).json();
+
+    return res.json({ data });
+  }
+
+  @Patch(':id')
+  async update(
+    @Param() params: { id: string },
+    @Body(new ZodValidationPipe(createAssignorSchema.partial()))
+    payload: CreateAssignorSchema,
+    @Res() res: Response,
+  ) {
+    const data = await this.service.update(params.id, payload);
+
+    if (!data) return res.status(404).json();
+
+    return res.json({ data });
+  }
+
+  @Delete(':id')
+  async delete(@Param() params: { id: string }, @Res() res: Response) {
+    const data = await this.service.delete(params.id);
+
+    if (!data) return res.status(404).json();
+
+    return res.json({ data });
+  }
+}

--- a/apps/backend/src/domains/assignor/assignor.module.ts
+++ b/apps/backend/src/domains/assignor/assignor.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { AssignorController } from './assignor.controller';
+import { AssignorService } from './assignor.service';
+import { PrismaService } from 'src/services/prisma.service';
+
+@Module({
+  imports: [],
+  controllers: [AssignorController],
+  providers: [AssignorService, PrismaService],
+})
+export class AssignorModule {}

--- a/apps/backend/src/domains/assignor/assignor.service.ts
+++ b/apps/backend/src/domains/assignor/assignor.service.ts
@@ -1,0 +1,69 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/services/prisma.service';
+import { PaginationSchema } from 'src/schemas/pagination.schema';
+import { CreateAssignorSchema } from 'src/schemas/assignor.schema';
+
+@Injectable()
+export class AssignorService {
+  constructor(private prisma: PrismaService) {}
+
+  index(pagination: PaginationSchema) {
+    return Promise.all([
+      this.prisma.assignor.findMany({
+        take: pagination.limit,
+        skip: (pagination.page - 1) * pagination.limit,
+      }),
+      this.prisma.assignor
+        .aggregate({
+          _count: { id: true },
+          take: pagination.limit,
+          skip: (pagination.page - 1) * pagination.limit,
+        })
+        .then((response) => ({
+          page: pagination.page,
+          pages: Math.ceil(response._count.id / pagination.limit),
+          total: response._count.id,
+          limit: pagination.limit,
+        })),
+    ]);
+  }
+
+  store(data: CreateAssignorSchema) {
+    return this.prisma.assignor.create({
+      data: {
+        document: data.document,
+        email: data.email,
+        name: data.name,
+        phone: data.phone,
+      },
+    });
+  }
+
+  show(id: string) {
+    return this.prisma.payable.findUnique({
+      where: { id },
+    });
+  }
+
+  update(id: string, data: CreateAssignorSchema) {
+    return this.prisma.assignor.update({
+      data,
+
+      where: {
+        id,
+      },
+    });
+  }
+
+  async delete(id: string) {
+    try {
+      const data = await this.prisma.payable.delete({
+        where: { id },
+      });
+
+      return data;
+    } catch (e) {
+      return undefined;
+    }
+  }
+}

--- a/apps/backend/src/domains/auth/auth.controller.ts
+++ b/apps/backend/src/domains/auth/auth.controller.ts
@@ -1,0 +1,7 @@
+import { Controller } from '@nestjs/common';
+import { AuthService } from './auth.service';
+
+@Controller('integrations/auth')
+export class AuthController {
+  constructor(private readonly service: AuthService) {}
+}

--- a/apps/backend/src/domains/auth/auth.module.ts
+++ b/apps/backend/src/domains/auth/auth.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { PrismaService } from 'src/services/prisma.service';
+
+@Module({
+  imports: [],
+  controllers: [AuthController],
+  providers: [AuthService, PrismaService],
+})
+export class AuthModule {}

--- a/apps/backend/src/domains/auth/auth.service.ts
+++ b/apps/backend/src/domains/auth/auth.service.ts
@@ -1,0 +1,69 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/services/prisma.service';
+import { PaginationSchema } from 'src/schemas/pagination.schema';
+import { CreateAssignorSchema } from 'src/schemas/assignor.schema';
+
+@Injectable()
+export class AuthService {
+  constructor(private prisma: PrismaService) {}
+
+  index(pagination: PaginationSchema) {
+    return Promise.all([
+      this.prisma.assignor.findMany({
+        take: pagination.limit,
+        skip: (pagination.page - 1) * pagination.limit,
+      }),
+      this.prisma.assignor
+        .aggregate({
+          _count: { id: true },
+          take: pagination.limit,
+          skip: (pagination.page - 1) * pagination.limit,
+        })
+        .then((response) => ({
+          page: pagination.page,
+          pages: Math.ceil(response._count.id / pagination.limit),
+          total: response._count.id,
+          limit: pagination.limit,
+        })),
+    ]);
+  }
+
+  store(data: CreateAssignorSchema) {
+    return this.prisma.assignor.create({
+      data: {
+        document: data.document,
+        email: data.email,
+        name: data.name,
+        phone: data.phone,
+      },
+    });
+  }
+
+  show(id: string) {
+    return this.prisma.payable.findUnique({
+      where: { id },
+    });
+  }
+
+  update(id: string, data: CreateAssignorSchema) {
+    return this.prisma.assignor.update({
+      data,
+
+      where: {
+        id,
+      },
+    });
+  }
+
+  async delete(id: string) {
+    try {
+      const data = await this.prisma.payable.delete({
+        where: { id },
+      });
+
+      return data;
+    } catch (e) {
+      return undefined;
+    }
+  }
+}

--- a/apps/backend/src/domains/payable/payable.controller.ts
+++ b/apps/backend/src/domains/payable/payable.controller.ts
@@ -4,6 +4,7 @@ import {
   Get,
   Param,
   Post,
+  Query,
   Res,
   UsePipes,
 } from '@nestjs/common';
@@ -11,13 +12,25 @@ import { PayableService } from './payable.service';
 import { ZodValidationPipe } from 'src/pipes/zod.validation.pipe';
 import { CreatePayableDto, createPayableSchema } from './payable.schema';
 import { Response } from 'express';
+import {
+  PaginationSchema,
+  paginationSchema,
+} from 'src/schemas/pagination.schema';
 
 @Controller('integrations/payable')
 export class PayableController {
   constructor(private readonly service: PayableService) {}
 
   @Get()
-  index() {}
+  @UsePipes(new ZodValidationPipe(paginationSchema))
+  async index(@Query() query: PaginationSchema) {
+    const [data, metadata] = await this.service.index(query);
+
+    return {
+      data,
+      ...metadata,
+    };
+  }
 
   @Post()
   @UsePipes(new ZodValidationPipe(createPayableSchema))

--- a/apps/backend/src/domains/payable/payable.controller.ts
+++ b/apps/backend/src/domains/payable/payable.controller.ts
@@ -1,18 +1,18 @@
 import { Body, Controller, Get, Post, UsePipes } from '@nestjs/common';
 import { PayableService } from './payable.service';
 import { ZodValidationPipe } from 'src/pipes/zod.validation.pipe';
-import { CreateCatDto, createCatSchema } from './payable.schema';
+import { CreatePayableDto, createPayableSchema } from './payable.schema';
 
 @Controller('integrations/payable')
 export class PayableController {
-  constructor(private readonly appService: PayableService) {}
+  constructor(private readonly service: PayableService) {}
 
   @Get()
   index() {}
 
   @Post()
-  @UsePipes(new ZodValidationPipe(createCatSchema))
-  store(@Body() data: CreateCatDto) {
-    return data;
+  @UsePipes(new ZodValidationPipe(createPayableSchema))
+  store(@Body() data: CreatePayableDto) {
+    return this.service.store(data);
   }
 }

--- a/apps/backend/src/domains/payable/payable.controller.ts
+++ b/apps/backend/src/domains/payable/payable.controller.ts
@@ -6,7 +6,6 @@ import {
   Param,
   Patch,
   Post,
-  Put,
   Query,
   Res,
   UsePipes,

--- a/apps/backend/src/domains/payable/payable.controller.ts
+++ b/apps/backend/src/domains/payable/payable.controller.ts
@@ -1,7 +1,16 @@
-import { Body, Controller, Get, Post, UsePipes } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Res,
+  UsePipes,
+} from '@nestjs/common';
 import { PayableService } from './payable.service';
 import { ZodValidationPipe } from 'src/pipes/zod.validation.pipe';
 import { CreatePayableDto, createPayableSchema } from './payable.schema';
+import { Response } from 'express';
 
 @Controller('integrations/payable')
 export class PayableController {
@@ -12,7 +21,18 @@ export class PayableController {
 
   @Post()
   @UsePipes(new ZodValidationPipe(createPayableSchema))
-  store(@Body() data: CreatePayableDto) {
-    return this.service.store(data);
+  async store(@Body() payload: CreatePayableDto) {
+    const data = await this.service.store(payload);
+
+    return { data };
+  }
+
+  @Get(':id')
+  async show(@Param() params: { id: string }, @Res() res: Response) {
+    const data = await this.service.show(params.id);
+
+    if (!data) return res.status(404).json();
+
+    return res.json({ data });
   }
 }

--- a/apps/backend/src/domains/payable/payable.controller.ts
+++ b/apps/backend/src/domains/payable/payable.controller.ts
@@ -1,21 +1,31 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Param,
+  Patch,
   Post,
+  Put,
   Query,
   Res,
   UsePipes,
 } from '@nestjs/common';
 import { PayableService } from './payable.service';
 import { ZodValidationPipe } from 'src/pipes/zod.validation.pipe';
-import { CreatePayableDto, createPayableSchema } from './payable.schema';
+import {
+  CreatePayableWithAssignorDto,
+  createPayableWithAssignorSchema,
+} from './payable.schema';
 import { Response } from 'express';
 import {
   PaginationSchema,
   paginationSchema,
 } from 'src/schemas/pagination.schema';
+import {
+  CreatePayableSchema,
+  createPayableSchema,
+} from 'src/schemas/payable.schema';
 
 @Controller('integrations/payable')
 export class PayableController {
@@ -33,8 +43,10 @@ export class PayableController {
   }
 
   @Post()
-  @UsePipes(new ZodValidationPipe(createPayableSchema))
-  async store(@Body() payload: CreatePayableDto) {
+  async store(
+    @Body(new ZodValidationPipe(createPayableWithAssignorSchema))
+    payload: CreatePayableWithAssignorDto,
+  ) {
     const data = await this.service.store(payload);
 
     return { data };
@@ -43,6 +55,29 @@ export class PayableController {
   @Get(':id')
   async show(@Param() params: { id: string }, @Res() res: Response) {
     const data = await this.service.show(params.id);
+
+    if (!data) return res.status(404).json();
+
+    return res.json({ data });
+  }
+
+  @Patch(':id')
+  async update(
+    @Param() params: { id: string },
+    @Body(new ZodValidationPipe(createPayableSchema.partial()))
+    payload: CreatePayableSchema,
+    @Res() res: Response,
+  ) {
+    const data = await this.service.update(params.id, payload);
+
+    if (!data) return res.status(404).json();
+
+    return res.json({ data });
+  }
+
+  @Delete(':id')
+  async delete(@Param() params: { id: string }, @Res() res: Response) {
+    const data = await this.service.delete(params.id);
 
     if (!data) return res.status(404).json();
 

--- a/apps/backend/src/domains/payable/payable.module.ts
+++ b/apps/backend/src/domains/payable/payable.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { PayableController } from './payable.controller';
 import { PayableService } from './payable.service';
+import { PrismaService } from 'src/services/prisma.service';
 
 @Module({
+  imports: [],
   controllers: [PayableController],
-  providers: [PayableService],
+  providers: [PayableService, PrismaService],
 })
 export class PayableModule {}

--- a/apps/backend/src/domains/payable/payable.schema.ts
+++ b/apps/backend/src/domains/payable/payable.schema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const createPayableSchema = z
+export const createPayableWithAssignorSchema = z
   .object({
     value: z.number(),
     emissionDate: z.string().datetime(),
@@ -15,4 +15,6 @@ export const createPayableSchema = z
   })
   .required();
 
-export type CreatePayableDto = z.infer<typeof createPayableSchema>;
+export type CreatePayableWithAssignorDto = z.infer<
+  typeof createPayableWithAssignorSchema
+>;

--- a/apps/backend/src/domains/payable/payable.schema.ts
+++ b/apps/backend/src/domains/payable/payable.schema.ts
@@ -1,15 +1,18 @@
 import { z } from 'zod';
 
-export const createCatSchema = z.object({
-  id: z.string().uuid(),
-  value: z.number(),
-  emissionDate: z.date(),
-  assignor: z.object({
-    document: z.string().max(30),
-    email: z.string().max(140),
-    phone: z.string().max(20),
-    name: z.string().max(140),
-  }),
-});
+export const createPayableSchema = z
+  .object({
+    value: z.number(),
+    emissionDate: z.string().datetime(),
+    assignor: z
+      .object({
+        document: z.string().max(30),
+        email: z.string().max(140),
+        phone: z.string().max(20),
+        name: z.string().max(140),
+      })
+      .required(),
+  })
+  .required();
 
-export type CreateCatDto = z.infer<typeof createCatSchema>;
+export type CreatePayableDto = z.infer<typeof createPayableSchema>;

--- a/apps/backend/src/domains/payable/payable.service.ts
+++ b/apps/backend/src/domains/payable/payable.service.ts
@@ -1,4 +1,25 @@
 import { Injectable } from '@nestjs/common';
+import { CreatePayableDto } from './payable.schema';
+import { PrismaService } from 'src/services/prisma.service';
 
 @Injectable()
-export class PayableService {}
+export class PayableService {
+  constructor(private prisma: PrismaService) {}
+
+  store(data: CreatePayableDto) {
+    return this.prisma.payable.create({
+      data: {
+        emissionDate: data.emissionDate,
+        value: data.value,
+        assignor: {
+          create: {
+            document: data.assignor.document,
+            email: data.assignor.email,
+            name: data.assignor.name,
+            phone: data.assignor.phone,
+          },
+        },
+      },
+    });
+  }
+}

--- a/apps/backend/src/domains/payable/payable.service.ts
+++ b/apps/backend/src/domains/payable/payable.service.ts
@@ -20,6 +20,16 @@ export class PayableService {
           },
         },
       },
+
+      include: {
+        assignor: true,
+      },
+    });
+  }
+
+  show(id: string) {
+    return this.prisma.payable.findUnique({
+      where: { id },
     });
   }
 }

--- a/apps/backend/src/domains/payable/payable.service.ts
+++ b/apps/backend/src/domains/payable/payable.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { CreatePayableDto } from './payable.schema';
+import { CreatePayableWithAssignorDto } from './payable.schema';
 import { PrismaService } from 'src/services/prisma.service';
 import { PaginationSchema } from 'src/schemas/pagination.schema';
 
@@ -28,7 +28,7 @@ export class PayableService {
     ]);
   }
 
-  store(data: CreatePayableDto) {
+  store(data: CreatePayableWithAssignorDto) {
     return this.prisma.payable.create({
       data: {
         emissionDate: data.emissionDate,
@@ -53,5 +53,30 @@ export class PayableService {
     return this.prisma.payable.findUnique({
       where: { id },
     });
+  }
+
+  update(id: string, data: CreatePayableWithAssignorDto) {
+    return this.prisma.payable.update({
+      data: {
+        emissionDate: data.emissionDate,
+        value: data.value,
+      },
+
+      where: {
+        id,
+      },
+    });
+  }
+
+  async delete(id: string) {
+    try {
+      const data = await this.prisma.payable.delete({
+        where: { id },
+      });
+
+      return data;
+    } catch (e) {
+      return undefined;
+    }
   }
 }

--- a/apps/backend/src/domains/payable/payable.service.ts
+++ b/apps/backend/src/domains/payable/payable.service.ts
@@ -1,10 +1,32 @@
 import { Injectable } from '@nestjs/common';
 import { CreatePayableDto } from './payable.schema';
 import { PrismaService } from 'src/services/prisma.service';
+import { PaginationSchema } from 'src/schemas/pagination.schema';
 
 @Injectable()
 export class PayableService {
   constructor(private prisma: PrismaService) {}
+
+  index(pagination: PaginationSchema) {
+    return Promise.all([
+      this.prisma.payable.findMany({
+        take: pagination.limit,
+        skip: (pagination.page - 1) * pagination.limit,
+      }),
+      this.prisma.payable
+        .aggregate({
+          _count: { id: true },
+          take: pagination.limit,
+          skip: (pagination.page - 1) * pagination.limit,
+        })
+        .then((response) => ({
+          page: pagination.page,
+          pages: Math.ceil(response._count.id / pagination.limit),
+          total: response._count.id,
+          limit: pagination.limit,
+        })),
+    ]);
+  }
 
   store(data: CreatePayableDto) {
     return this.prisma.payable.create({

--- a/apps/backend/src/schemas/assignor.schema.ts
+++ b/apps/backend/src/schemas/assignor.schema.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const createAssignorSchema = z.object({
+  document: z.string().max(30),
+  email: z.string().max(140),
+  phone: z.string().max(20),
+  name: z.string().max(140),
+});
+
+export type CreateAssignorSchema = z.infer<typeof createAssignorSchema>;

--- a/apps/backend/src/schemas/pagination.schema.ts
+++ b/apps/backend/src/schemas/pagination.schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const paginationSchema = z.object({
+  page: z.coerce.number().default(1),
+  limit: z.coerce.number().default(25),
+  q: z.string().default(''),
+});
+
+export type PaginationSchema = z.infer<typeof paginationSchema>;

--- a/apps/backend/src/schemas/payable.schema.ts
+++ b/apps/backend/src/schemas/payable.schema.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const createPayableSchema = z.object({
+  value: z.number(),
+  emissionDate: z.string().datetime(),
+});
+
+export type CreatePayableSchema = z.infer<typeof createPayableSchema>;

--- a/apps/backend/src/services/prisma.service.ts
+++ b/apps/backend/src/services/prisma.service.ts
@@ -1,0 +1,9 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PrismaService extends PrismaClient implements OnModuleInit {
+  async onModuleInit() {
+    await this.$connect();
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -895,6 +895,47 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.1.0.tgz#7d8dacb7fdef0e4387caf7396cbd77f179867d06"
   integrity sha512-Zwq5OCzuwJC2jwqmpEQt7Ds1DTi6BWSwoGkbb1n9pO3hzb35BoJELx7c0T23iDkBGkh2e7tvOtjF3tr3OaQHDQ==
 
+"@prisma/client@^5.7.1":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-5.7.1.tgz#a124afd05663267f7255a639a81d28303684a063"
+  integrity sha512-TUSa4nUcC4nf/e7X3jyO1pEd6XcI/TLRCA0KjkA46RDIpxUaRsBYEOqITwXRW2c0bMFyKcCRXrH4f7h4q9oOlg==
+
+"@prisma/debug@5.7.1":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-5.7.1.tgz#064177066e630beb43492ffa608acc21a118e2ce"
+  integrity sha512-yrVSO/YZOxdeIxcBtZ5BaNqUfPrZkNsAKQIQg36cJKMxj/VYK3Vk5jMKkI+gQLl0KReo1YvX8GWKfV788SELjw==
+
+"@prisma/engines-version@5.7.1-1.0ca5ccbcfa6bdc81c003cf549abe4269f59c41e5":
+  version "5.7.1-1.0ca5ccbcfa6bdc81c003cf549abe4269f59c41e5"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-5.7.1-1.0ca5ccbcfa6bdc81c003cf549abe4269f59c41e5.tgz#b7845425313e5395a3a3e64f3e0d04c1f320fa92"
+  integrity sha512-dIR5IQK/ZxEoWRBDOHF87r1Jy+m2ih3Joi4vzJRP+FOj5yxCwS2pS5SBR3TWoVnEK1zxtLI/3N7BjHyGF84fgw==
+
+"@prisma/engines@5.7.1":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-5.7.1.tgz#631c27daa326bbacd5d7119446e0d3f15c0f274c"
+  integrity sha512-R+Pqbra8tpLP2cvyiUpx+SIKglav3nTCpA+rn6826CThviQ8yvbNG0s8jNpo51vS9FuZO3pOkARqG062vKX7uA==
+  dependencies:
+    "@prisma/debug" "5.7.1"
+    "@prisma/engines-version" "5.7.1-1.0ca5ccbcfa6bdc81c003cf549abe4269f59c41e5"
+    "@prisma/fetch-engine" "5.7.1"
+    "@prisma/get-platform" "5.7.1"
+
+"@prisma/fetch-engine@5.7.1":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-5.7.1.tgz#d7baa3493867c6f7cedfc41df477cfd0963059ca"
+  integrity sha512-9ELauIEBkIaEUpMIYPRlh5QELfoC6pyHolHVQgbNxglaINikZ9w9X7r1TIePAcm05pCNp2XPY1ObQIJW5nYfBQ==
+  dependencies:
+    "@prisma/debug" "5.7.1"
+    "@prisma/engines-version" "5.7.1-1.0ca5ccbcfa6bdc81c003cf549abe4269f59c41e5"
+    "@prisma/get-platform" "5.7.1"
+
+"@prisma/get-platform@5.7.1":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-5.7.1.tgz#bc2fe43838c7d47b321aa4728a0f60990d02bc9e"
+  integrity sha512-eDlswr3a1m5z9D/55Iyt/nZqS5UpD+DZ9MooBB3hvrcPhDQrcf9m4Tl7buy4mvAtrubQ626ECtb8c6L/f7rGSQ==
+  dependencies:
+    "@prisma/debug" "5.7.1"
+
 "@rushstack/eslint-patch@^1.3.3":
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.6.1.tgz#9ab8f811930d7af3e3d549183a50884f9eb83f36"
@@ -5588,6 +5629,13 @@ pretty-format@^29.0.0, pretty-format@^29.7.0:
     "@jest/schemas" "^29.6.3"
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
+
+prisma@^5.7.1:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-5.7.1.tgz#af60ed90531adc0ab8a683c9b1fc86d841c39864"
+  integrity sha512-ekho7ziH0WEJvC4AxuJz+ewRTMskrebPcrKuBwcNzVDniYxx+dXOGcorNeIb9VEMO5vrKzwNYvhD271Ui2jnNw==
+  dependencies:
+    "@prisma/engines" "5.7.1"
 
 process-nextick-args@~2.0.0:
   version "2.0.1"


### PR DESCRIPTION
Utilize o Prisma, para incluir um novo banco de dados SQLite.

Crie a estrutura de acordo com o que foi definido.

Caso os dados estejam válidos, cadastre-os.

Crie 2 novas rotas:

`GET /integrations/payable/:id`

`GET /integrations/assignor/:id`

Para que seja possível retornar pagáveis e cedentes de forma independete.

Inclua também rotas para as outras operações:

- Edição;
- Exclusão;
- Cadastro;