### PR TITLE
backend 5 - permission

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -36,6 +36,7 @@
     "@nestjs/cli": "^10.0.0",
     "@nestjs/schematics": "^10.0.0",
     "@nestjs/testing": "^10.0.0",
+    "@types/bcryptjs": "^2.4.6",
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.2",
     "@types/node": "^20.3.1",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -25,6 +25,7 @@
     "@nestjs/jwt": "^10.2.0",
     "@nestjs/platform-express": "^10.0.0",
     "@prisma/client": "^5.7.1",
+    "bcryptjs": "^2.4.3",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "reflect-metadata": "^0.1.13",

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -13,7 +13,7 @@ datasource db {
 model User {
 	id String @id @default(uuid())
 
-	login String
+	login String @unique
 	password String
 }
 

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -10,6 +10,13 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+model User {
+	id String @id @default(uuid())
+
+	login String
+	password String
+}
+
 model Payable {
 	id String @id @default(uuid())
 

--- a/apps/backend/src/domains/auth/auth.controller.ts
+++ b/apps/backend/src/domains/auth/auth.controller.ts
@@ -23,7 +23,24 @@ export class AuthController {
     }
 
     return {
-      token: await this.service.token({ user: payload.login }),
+      token: await this.service.token(validated),
+      data: validated,
+    };
+  }
+
+  @Post('signup')
+  @Public()
+  async signup(
+    @Body(new ZodValidationPipe(signInSchema)) payload: SignInSchema,
+  ) {
+    const validated = await this.service.signUp(
+      payload.login,
+      payload.password,
+    );
+
+    return {
+      token: await this.service.token(validated),
+      data: validated,
     };
   }
 }

--- a/apps/backend/src/domains/auth/auth.service.ts
+++ b/apps/backend/src/domains/auth/auth.service.ts
@@ -1,12 +1,47 @@
-import { Injectable } from '@nestjs/common';
+import * as bcrypt from 'bcryptjs';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
+import { PrismaService } from 'src/services/prisma.service';
 
 @Injectable()
 export class AuthService {
-  constructor(private jwt: JwtService) {}
+  constructor(
+    private jwt: JwtService,
+    private prisma: PrismaService,
+  ) {}
+
+  async signUp(login: string, password: string) {
+    const previous = await this.prisma.user.findUnique({ where: { login } });
+
+    if (previous) {
+      throw new BadRequestException([
+        { code: 'user_already_exists', message: 'User already registered' },
+      ]);
+    }
+
+    return this.prisma.user.create({
+      data: {
+        login,
+        password: await bcrypt.hash(password, 10),
+      },
+      select: {
+        id: true,
+        login: true,
+      },
+    });
+  }
 
   async signIn(login: string, password: string) {
-    return login === 'aprovame' && password === 'aprovame';
+    const user = await this.prisma.user.findUnique({ where: { login } });
+
+    if (!user || !(await bcrypt.compare(password, user.password))) {
+      return false;
+    }
+
+    return {
+      id: user.id,
+      login: user.login,
+    };
   }
 
   token(payload: Record<string, unknown>) {

--- a/apps/backend/src/pipes/zod.validation.pipe.ts
+++ b/apps/backend/src/pipes/zod.validation.pipe.ts
@@ -15,6 +15,7 @@ export class ZodValidationPipe implements PipeTransform {
             code: entry.message === 'Required' ? 'required' : entry.code,
             maximum: (entry as unknown as { maximum: number }).maximum,
             field: entry.path.join('.'),
+            message: entry.message,
           })),
         );
       }

--- a/apps/backend/vercel.json
+++ b/apps/backend/vercel.json
@@ -1,0 +1,15 @@
+{
+	"version": 2,
+	"builds": [
+		{
+			"src": "dist/main.js",
+			"use": "@vercel/node"
+		}
+	],
+	"routes": [
+		{
+			"src": "/(.*)",
+			"dest": "dist/main.js"
+		}
+	]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2004,6 +2004,11 @@ basic-ftp@^5.0.2:
   resolved "https://registry.yarnpkg.com/basic-ftp/-/basic-ftp-5.0.4.tgz#28aeab7bfbbde5f5d0159cd8bb3b8e633bbb091d"
   integrity sha512-8PzkB0arJFV4jJWSGOYR+OEic6aeKMu/osRhBULN6RY0ykby6LKhbmuQ5ublvaas5BOwboah5D87nrHyuh8PPA==
 
+bcryptjs@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/bcryptjs/-/bcryptjs-2.4.3.tgz#9ab5627b93e60621ff7cdac5da9733027df1d0cb"
+  integrity sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==
+
 binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1068,6 +1068,11 @@
   dependencies:
     "@babel/types" "^7.20.7"
 
+"@types/bcryptjs@^2.4.6":
+  version "2.4.6"
+  resolved "https://registry.yarnpkg.com/@types/bcryptjs/-/bcryptjs-2.4.6.tgz#2b92e3c2121c66eba3901e64faf8bb922ec291fa"
+  integrity sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==
+
 "@types/body-parser@*":
   version "1.19.5"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.5.tgz#04ce9a3b677dc8bd681a17da1ab9835dc9d3ede4"


### PR DESCRIPTION
Agora, crie um sistema de gerenciamento de permissões.

Crie um novo cadastro de permissões. Esse cadastro deve armazenar: `login` e `password`.

Refatore o endpoint de autenticação para que sempre se gere JWTs se login e senha estiverem cadastrados no Banco de Dados.